### PR TITLE
docs(setup): document LINE channel duplication and develop branch workflow

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,4 +1,7 @@
 # LINE Messaging API
+# ローカルは TEST モードで sandbox リポに向くだけなので、ここに入れる値は本番 / DEV どちらでも実害なし。
+# 通常は DEV チャンネルの値を入れる（develop ブランチで触る Vercel Preview と同じ環境を再現するため）。
+# Vercel 上では Production = 本番チャンネル / Preview + Development = DEV チャンネル の同名キー × 環境別エントリで運用（docs/SETUP.md §7.3 参照）。
 LINE_CHANNEL_SECRET=（LINE Developers から取得する Channel Secret）
 LINE_CHANNEL_ACCESS_TOKEN=（LINE Developers から取得する Channel Access Token）
 

--- a/docs/KNOWLEDGE.md
+++ b/docs/KNOWLEDGE.md
@@ -4,6 +4,34 @@
 
 ---
 
+## 2026-04-19（LINE チャンネル二重化セッション: 家族公開前ブロッカー解消）
+
+### 技術的な気づき（LINE チャンネル二重化）
+
+- **Vercel SHA dedup の罠**: 新規ブランチを push しても、HEAD が既存ブランチと**同じ commit SHA を指している**と Vercel は Preview デプロイを作らない。`develop` を `main` から切って即 push しただけだと `DEPLOYMENT_NOT_FOUND` のまま固まる。空 commit (`git commit --allow-empty`) で分岐させると即ビルド開始する。Vercel Dashboard の Deployments タブで該当ブランチの deployment が 1 件も無い場合、まず SHA 重複を疑う
+- **同名 env × 環境別エントリは LINE 系にも有効**: [docs/SETUP.md §8.2](./SETUP.md) の `GITHUB_REPO` で実証済みの「同じキー名で Production と Preview/Development に別値を持つ」パターンを `LINE_CHANNEL_SECRET` / `LINE_CHANNEL_ACCESS_TOKEN` にもそのまま適用できた。**コード変更ゼロ**（[src/lib/env.ts](../src/lib/env.ts) の getter は `process.env[X]` を引くだけで Vercel 側が環境別に注入してくれる）。env getter に環境分岐ロジックを書く案も検討したが、Vercel ネイティブで解ける場面で getter を複雑化するメリットなし
+- **`@line/bot-sdk` v11 の Webhook 署名検証は LINE Verify ボタンの「空 events POST」も同じ署名計算で通る**: 新チャンネルの Webhook URL Verify が即 Success になる前提条件。`validateSignature(rawBody, secret, signature)` の `rawBody` が空文字列 `""` でも署名計算は成立する設計
+
+### UX・会話設計の気づき（LINE チャンネル二重化）
+
+- **手順書の「正」原則**: Claude Code が古い記憶で外部 UI 手順を体当たり推測するのは禁じ手。SETUP.md §2.3 で「Messaging API の利用を有効化」が 1 行で済まされていて、実際は「設定（歯車）→ Messaging API → 「Messaging APIを利用する」→ 既存 Provider 選択」の 4 ステップが必要だったが、ひろゆきさんが Claude in Chrome に逃げて解決する事態になった。今回 SETUP.md §2.3 を加筆 + memory に「外部 UI で確信が持てない手順は Claude in Chrome に質問文を渡す」ルールを保存（`feedback_external_ui_escalation.md`）
+
+### 家族レビューからのフィードバック
+
+- **Bot 応答までの無音が不安**: ひろゆきさん本人の自己レビュー（家族役）から「Bot が反応するまで黙っているのは（LINE では普通だけど）不安になる」の指摘。現状 Gemini 整形 + GitHub 起票で 2-3 秒の沈黙が発生。CS プロ視点では「届いた / 届かない」の区別が無い時間は体験として劣る。Phase 2 で **2 段返信**（受信即「受け取りました、考えてます…」を `replyMessage` で返し、Issue 起票完了後に URL を `pushMessage` で通知）を検討する。B 案（Redis 会話状態機械）と合流させると `gathering` 状態 = 即時 ACK の自然な拡張になるので、合流案が有力（[TASKS.md Phase 2 候補](./TASKS.md) 参照）
+
+### 運用・設計の気づき
+
+- **branch 戦略移行の判定**: [WORKFLOW.md](./WORKFLOW.md) で挙げていた「main 直 → feature branch + PR 移行」のトリガー 4 つのうち、**「変更を本番に反映する前にステージングで家族に触ってもらって寝かせる運用が必要」**が家族公開準備のタイミングで現実化した。LINE チャンネル二重化と branch 運用変更は同時に着手するのが正解（片方だけだと中途半端に「DEV チャンネル無しで develop 運用」or「main 直で DEV チャンネル」になり意味が薄い）
+- **Vercel Preview の固定 URL 命名規則**: `feedback-relay-bot-git-<branch>-<team-slug>.vercel.app` の `<team-slug>` 部分はチーム単位で一意（本プロジェクトでは `hirobirofran-7375s-projects`）。main の既存 alias を見れば develop 用の URL が事前に確定できるので、LINE Webhook URL 設定を develop push 前に下準備しておくことも可能（実際は push → ビルド完了を待ってから Verify する方が安全）
+
+### 次回セッションへの申し送り（LINE チャンネル二重化）
+
+- 家族公開前のブロッカーは全部潰れた。残るは (a) Phase 2 着手（B 案 = Redis 会話状態 or 二段返信、合流案推奨） / (b) [docs/SETUP.md §8](./SETUP.md) の Production 切替（家族公開タイミングで実施） / (c) ラベル運用 / (d) follow event 初回あいさつ、の 4 つの中から優先度判断
+- **本セッションで develop 運用に移行**。今後 Claude Code は原則 develop にコミット → develop → main の PR を切る運用。詳細は [WORKFLOW.md](./WORKFLOW.md) 参照
+- DEV チャンネル運用の継続的な意義は「main 反映前の本人ドッグフード」。Preview デプロイで sandbox リポに起票テストを通せるので、テストスイート未整備の現状でもデグレ検知の手段になる
+- ローカル `.env.local` は TEST モード（sandbox 向き）なので LINE 系に DEV/本番どちらの値を入れても実害なし。通常は DEV チャンネル値を入れて Vercel Preview と環境を揃えるのが推奨（[.env.local.example](../.env.local.example) コメント追記済み）
+
 ## 2026-04-19（Phase 1 仕上げセッション: 返信文リライト + SETUP §8）
 
 ### UX・会話設計の気づき

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -57,9 +57,14 @@ Provider は複数のチャンネルをまとめる会社/組織単位のコン�
     | 接続先の組織 | ビジネスマネージャーの組織名を入力（例: `食材管理アプリ フィードバック窓口`）。これは OA 側の組織コンテナで Provider とは別概念 |
 
 3. 規約同意 → **作成**
-4. Official Account Manager の設定画面で **Messaging API** の利用を有効化
-5. Provider 選択ダイアログで **既存の `hirobirofran` を選ぶ**（新規作成しない。管理がバラける）
-6. 有効化完了 → Developers Console に戻るとチャンネルが自動で出現している
+4. Official Account Manager で Messaging API を有効化:
+    1. 作成完了画面 / OA ホームから対象アカウントを開く
+    2. 画面**右上の歯車アイコン（設定）** → 左メニュー **「Messaging API」** をクリック
+    3. **「Messaging APIを利用する」** ボタンを押す
+    4. プロバイダー選択ダイアログ → **「既存のプロバイダーを選択」** → **`hirobirofran`** を選ぶ（新規作成しない。管理がバラける）
+    5. プライバシーポリシー / 利用規約 URL は**空欄のまま OK**（後から追加可）
+    6. 同意にチェック → **OK**
+5. 有効化完了 → Developers Console (`https://developers.line.biz/console/`) のタブをリロードすると `hirobirofran` プロバイダー配下にチャンネルが自動で出現している
 
 作成直後にここで一旦休憩可能。続きは 2.4 以降（チャンネル設定と Token 取得）。
 
@@ -476,14 +481,74 @@ curl -s https://feedback-relay-bot.vercel.app/api/line/webhook
 
 ローカル dev で同じ userId で試せるように、`.env.local` の `ALLOWED_LINE_USER_IDS=` にも同じ値を入れておく。`.env.local.example` には**値を貼らない**（プレースホルダのまま）。
 
-## 7. （欠番・予約）
+## 7. LINE チャンネル二重化（DEV チャンネル新設）
 
-Phase 2（Redis 会話状態機械 / 会話設計の見直し）の手順枠として欠番扱い。実装着手時にここを埋める。
+家族公開後に「main へ壊れた変更を入れたら即家族の Bot に反映される」リスクを避けるため、本番チャンネルとは別に **DEV 用 LINE チャンネル**を立て、Vercel Preview デプロイ（`develop` ブランチ）に紐付ける。これにより `develop` ブランチで本人が触って寝かせてから main にマージ、という運用が可能になる。
+
+> **Claude Code への指示:** 本セクションは「家族公開前に必ず完了させる」位置付け（[TASKS.md](./TASKS.md) ブロッカー）。実装は §2.3〜§2.6 の本番チャンネル作成手順を**そのまま再利用**する。差分は §7.2 の表のみ。
+
+### 7.1 方針
+
+- **DEV チャンネル**: 同じ Provider `hirobirofran` 配下に「食材アプリ 意見箱 DEV」を新設。本人のみ友達追加。**家族に QR / URL を絶対渡さない**（誤友達追加防止のためアイコンも本番と区別できるものにする）
+- **Vercel 環境マッピング**: Production = main → 本番チャンネル / Preview + Development = `develop` → DEV チャンネル
+- **env 戦略**: `LINE_CHANNEL_SECRET` / `LINE_CHANNEL_ACCESS_TOKEN` は同名キーで環境別に値を分ける（§8.2 の `GITHUB_REPO` と同パターン）。**コード変更不要**
+- **ホワイトリスト**: `ALLOWED_LINE_USER_IDS` は全環境共通（本人 userId のみ）
+
+### 7.2 DEV チャンネル新設（§2.3〜§2.6 の差分のみ）
+
+作成フローは本番チャンネルと同じ（§2.3〜§2.6）。以下の差分だけ意識する:
+
+| 工程 | 差分 |
+| --- | --- |
+| §2.3 OA 作成 | アカウント名を `食材アプリ 意見箱 DEV` にする（7 日間変更不可なので注意）。Provider 選択ダイアログでは**既存の `hirobirofran` を選ぶ** |
+| §2.4 Token 取得 | `.env.local` には書かない（ローカルは TEST モードで sandbox リポに向くだけなので DEV/本番どちらでも実害ないが、**手元のメモ帳に控える**だけにして §7.3 で Vercel UI に直接入力するのが安全） |
+| §2.5 応答設定 | 本番と同じ（チャット OFF / あいさつ OFF / 応答 OFF / Webhook はいったん OFF） |
+| §2.6 友達追加 | **本人のみ**。家族には QR / URL を絶対渡さない |
+
+### 7.3 Vercel env 分割（LINE 系キー）
+
+§8.2 の `GITHUB_REPO` と同じ「同名キー × 環境別エントリ」パターン。
+
+1. Vercel Dashboard → feedback-relay-bot → **Settings** → **Environment Variables**
+2. 既存の `LINE_CHANNEL_SECRET` 行 → `⋯` → **Edit** → Environments を **Production だけ** に絞る（**Value は触らない** = 本番チャンネル Secret のまま）
+3. **Add New** → Key: `LINE_CHANNEL_SECRET` / Value: **DEV チャンネルの Channel Secret** / Environments: **Preview + Development** で追加
+4. `LINE_CHANNEL_ACCESS_TOKEN` も同手順（既存を Production に絞る → Add New で DEV 用を Preview + Development に追加）
+5. 結果: 4 エントリ（`LINE_CHANNEL_SECRET` × 2、`LINE_CHANNEL_ACCESS_TOKEN` × 2）が並ぶ。`mcp__vercel__vercel-get-environments` で `target` フィールドが `["production"]` と `["preview","development"]` に分かれていることを確認可能
+
+### 7.4 develop ブランチ運用への移行
+
+1. ローカルで `git checkout -b develop && git push -u origin develop`
+2. **要注意**: develop が main と同じ commit を指すと、Vercel が SHA dedup で **Preview デプロイを作らない**。develop に新しい commit を 1 つ載せて分岐させる必要がある（最初は空 commit でも可: `git commit --allow-empty -m "chore(deploy): trigger initial preview"`）
+3. push 後、Vercel が自動で Preview デプロイ作成（1〜2 分）。固定 URL は命名規則で確定: `https://feedback-relay-bot-git-develop-<team-slug>.vercel.app`
+4. 以降、ひろゆきさんの開発フローは **`develop` で実装 → 本人が DEV チャンネルで触って確認 → develop → main の PR → マージで本番反映** に切り替わる（[WORKFLOW.md](./WORKFLOW.md) 参照）
+
+### 7.5 DEV チャンネル Webhook URL 設定
+
+1. LINE Developers Console → DEV チャンネル → **Messaging API** タブ → **Webhook settings**
+2. **Webhook URL**: `https://feedback-relay-bot-git-develop-<team-slug>.vercel.app/api/line/webhook`（§7.4 で確認した URL）→ **Update**
+3. **Verify** ボタン → `Success.` を確認（§6.5.2 と同じ仕組み）
+4. **Use webhook** トグルを **ON**
+5. 本人の LINE で DEV チャンネルを友達追加（QR は §2.6 と同じ場所、Developers Console / OA Manager のいずれかから）
+
+### 7.6 実機疎通確認
+
+DEV と本番、両方の経路で動くことを確認する（env 分離が効いている保証）。
+
+1. 本人 LINE → **DEV チャンネル**に `DEV テスト送信` などのテキストを送信
+   - sandbox リポ（[feedback-relay-bot-sandbox](https://github.com/hirobirofran/feedback-relay-bot-sandbox/issues)）に **`[TEST]` プレフィックス付き Issue** が立つ
+   - LINE 返信に Issue 番号 + URL が含まれる
+2. 本人 LINE → **本番チャンネル**（既存）に `本番テスト送信` を送信
+   - **同じく sandbox リポに `[TEST]` Issue** が立つ（§8 の Production 切替前は本番経路も sandbox に向く設計のため正常動作）
+3. 動作確認 Issue は即 close（**Close as not planned**）
+
+**期待結果**: DEV/本番どちらの経路も「署名検証 → Issue 起票 → 返信」が独立して通る。片方だけ動かない場合は env 分離が崩れている可能性があるので §7.3 のスコープ設定をやり直す。
 
 ## 8. 家族公開前の Production 切替
 
 Phase 1 A 案完了直後は Production / Preview / Development 全環境が **sandbox リポ (`feedback-relay-bot-sandbox`) + `[TEST]` タイトル付与** で動いている。家族に LINE 公式アカウントの友達追加 URL を渡す前に、Production スコープだけを本丸リポに切り替える。
 
+> **前提**: §7 のチャンネル二重化（DEV チャンネル + develop ブランチ運用）が完了していること。§7 が無いまま §8 を実行すると「main に push した瞬間に家族の Bot に反映 + 本丸リポに起票」の二重リスクを背負うことになる。
+>
 > **Claude Code への指示:** このセクションは「家族公開」という判断が発生する瞬間にオーナー（ひろゆきさん）と一緒に実行する前提で書かれている。切替後は本丸リポ `hirobirofran/food-inventory-app` に実 Issue が立つので、誤実行のリスクが最も高い。必ず §8.5 の実機疎通まで終えてから家族に URL を渡す。
 
 ### 8.1 方針
@@ -508,7 +573,7 @@ Phase 1 A 案完了直後は Production / Preview / Development 全環境が **s
     - Preview / Development: `test`
 5. **`ALLOWED_LINE_USER_IDS` は全環境共通**（§6.5.3 で投入済み）のままで良い。家族分を追加する場合はここで**カンマ区切りで追記**（例: `U<本人>,U<家族1>,U<家族2>`）
 
-**秘密値は触らない**: `LINE_CHANNEL_SECRET` / `LINE_CHANNEL_ACCESS_TOKEN` / `GITHUB_TOKEN` / `GEMINI_API_KEY` / Upstash 資格情報は本セクションで変更する必要がない。
+**秘密値は触らない**: `GITHUB_TOKEN` / `GEMINI_API_KEY` / Upstash 資格情報は本セクションで変更する必要がない。`LINE_CHANNEL_SECRET` / `LINE_CHANNEL_ACCESS_TOKEN` も本セクションでは触らない（§7.3 で既に Production = 本番チャンネル / Preview+Development = DEV チャンネルに環境別エントリで分割済みのため、本切替で値の差し替えは不要）。
 
 ### 8.3 Vercel MCP 補足（Claude 伴走時）
 

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -36,15 +36,16 @@ Phase 0 完了。次は Phase 1 実装（[DESIGN.md §10](./DESIGN.md) の Phase
 - [x] **A 案（単発版）実装 + sandbox リポへの E2E 疎通**（2026-04-19、`feedback-relay-bot-sandbox` private リポ作成、PAT access 追加、Vercel env に `GITHUB_REPO=feedback-relay-bot-sandbox` + `FEEDBACK_BOT_MODE=test` 投入、LINE 実機メッセージで sandbox #1 起票成功、タイトルに `[TEST]` プレフィックス付与確認、Gemini の `## 背景 / ## 期待する動作 / ## 補足 / ## 元メッセージ` セクション構造通り）
 - [x] **Bot 返信 3 文言の家族目線リライト**（2026-04-19、[src/app/api/line/webhook/route.ts](../src/app/api/line/webhook/route.ts) の成功/失敗/非テキスト 3 リプライを「受領感謝 → 何が起きたか → 次の期待行動」の 3 要素で揃え直し。`npm run build` 通過、実機疎通確認は別途）
 - [x] **家族公開前切替手順の書き下し**（2026-04-19、[docs/SETUP.md §8](./SETUP.md) に Production 切替・Redeploy・実機疎通・ロールバックを書き下し。Preview/Development は sandbox 恒久維持してデグレ検知に使う方針を明記。実切替は家族公開タイミングで別途実施）
+- [x] **LINE チャンネル二重化（家族公開前ブロッカー解消）**（2026-04-19、DEV チャンネル「食材アプリ 意見箱 DEV」を同 Provider に新設、Vercel env で `LINE_CHANNEL_SECRET` / `LINE_CHANNEL_ACCESS_TOKEN` を Production = 本番チャンネル / Preview+Development = DEV チャンネルに環境別分割、`develop` ブランチ運用に移行して Preview 固定 URL `feedback-relay-bot-git-develop-hirobirofran-7375s-projects.vercel.app` に DEV チャンネル Webhook を紐付け。DEV/本番 両経路で実機疎通成功。手順は [docs/SETUP.md §7](./SETUP.md)、運用変更は [docs/WORKFLOW.md](./WORKFLOW.md) 参照。これで家族公開前ブロッカーが解消し、§8 Production 切替に進める状態になった）
 
 ### 🔲 次にやること（Phase 2 着手前）
 
-Phase 1 DoD 最短コース到達 + 家族公開前の軽い整備まで完了。以下は Phase 2 移行前の残選択肢:
+Phase 1 DoD 最短コース到達 + 家族公開前ブロッカー解消まで完了。以下は Phase 2 移行前の残選択肢:
 
 - **B: Redis 会話状態 + 状態機械**（`gathering`→`confirming`→`done`、起票前に「これで起票しますか？」の確認ステップ）
 - **ラベル運用**: sandbox / 本丸どちらも `from-family` ラベル整備、Gemini 出力の labels を採用する経路追加
 - **LINE follow event の初回あいさつ実装**（CLAUDE.md §会話設計の初手ルール 1 の未着手分。B 案の会話状態機械と合わせて再検討）
-- **🔴 LINE チャンネル二重化（家族公開前に必須）**: 現状 LINE チャンネル 1 つで Webhook は Production 固定。家族公開後は main push が即家族の Bot に反映される設計になっており、壊れた dev 版が家族に見えるリスク大。テスト用 LINE チャンネル（`食材アプリ 意見箱 DEV` 相当）を追加し、Preview デプロイの固定 URL（develop ブランチ運用 or Vercel Preview alias）に Webhook を向ける。env は `LINE_CHANNEL_SECRET` / `LINE_CHANNEL_ACCESS_TOKEN` を Production と Preview/Development で別値に分割。**家族への友達追加 URL を渡す前に完了必須**
+- **二段返信（即時 ACK → Issue 完了通知）**: 家族レビュー（本人セルフ）から「Bot 応答までの無音が不安」の指摘あり（[KNOWLEDGE.md 2026-04-19 セッション](./KNOWLEDGE.md) 参照）。受信即「受け取りました、考えてます…」を replyMessage で返し、Issue 起票完了で pushMessage で URL を通知する 2 段構成に変更する。B 案の会話状態機械とどちらを先にやるか要検討（B 案の `gathering` 状態 = 即時 ACK の自然な拡張なので、合流させた方がコスト効率が良い可能性）
 
 ## Phase 2: 家族展開（未着手）
 

--- a/docs/WORKFLOW.md
+++ b/docs/WORKFLOW.md
@@ -50,21 +50,19 @@ Conventional Commits + scope を採用。既存 commit log にならう:
 
 ## ブランチ・PR 運用
 
-**現在（イニシャル期）**: main 直コミットで進める。
+**現在（develop ブランチ運用期、2026-04-19〜）**: `develop → main` の PR 運用。
 
-- 理由: ソロ開発 + レビュー窓が「家族 = プロダクト評価観点」で **コード review は不要**。コードレビューに相当する品質担保は `docs/TASKS.md` の DoD チェックリストで代替
-- Vercel は main push 即デプロイなので、動作確認のたびにブランチを切る手間もない
+- **環境マッピング**:
+  - `main` → Vercel Production → **本番 LINE チャンネル「食材アプリ 意見箱」**（家族が見ている）
+  - `develop` → Vercel Preview（固定 URL `feedback-relay-bot-git-develop-<team>.vercel.app`）→ **DEV LINE チャンネル「食材アプリ 意見箱 DEV」**（本人のみ）
+- **基本フロー**: `develop` で実装・コミット → 本人が DEV チャンネルで触って確認 → 必要なら寝かせる → `develop → main` の PR を作成 → ひろゆきさんが GitHub UI でマージ → main 反映で家族の Bot が更新される
+- **Claude Code がコミットする先**: 原則 `develop`。main 直コミット禁止（緊急 hotfix で main から短命 fix branch を切るパターンは可、その場合は事前確認）
+- **PR 作成方針**: コミット粒度（前章）に従って自然な単位で develop に積み、ある程度まとまったら PR を切る。1 PR = 複数 commit で OK（むしろ過剰に PR を分けない）。PR title は最大の commit message を流用、body には変更点と動作確認結果を箇条書き
+- **マージ方針**: `Squash and merge` ではなく **通常の Merge commit**（commit 履歴を残して develop と main の対応を追えるようにする）
 
-**移行タイミング（= feature branch + PR を導入する時）**
+**移行の経緯（2026-04-19）**: 「移行タイミング」リストの 2 つめ「変更を本番に反映する前にステージングで家族に触ってもらって寝かせる運用が必要」が家族公開準備のタイミングで現実化。Vercel Preview + DEV LINE チャンネルの二重化（[docs/SETUP.md §7](./SETUP.md)）と同時に develop 運用へ移行した。
 
-以下のどれかに該当したら main 直運用を終える:
-
-- 2 人目以降の開発者（Claude 以外）が入る
-- 「変更を本番に反映する前にステージングで家族に触ってもらって 1 日寝かせる」運用が必要になった
-- 複数の機能を並行開発するため branch で分離する必要が出た
-- Phase 2 以降、壊すと家族が困るリスクが上がった
-
-移行時は本ファイルに「20YY-MM-DD 以降は feature branch + PR 運用」と追記する。
+**過去の運用（イニシャル期、〜2026-04-19）**: main 直コミット運用。理由はソロ開発 + 家族レビュアーで code review 不要、Vercel が main push 即デプロイなので branch を切る手間が無かったため。Phase 1 完了までこのモードで進めた。
 
 ## 参照
 


### PR DESCRIPTION
## Summary

- 家族公開前ブロッカー（LINE チャンネル二重化）が完了したので、再現可能な手順として SETUP.md §7 に記録
- 同時に branch 運用を main 直 → `develop → main` PR ベースに移行（WORKFLOW.md）
- KNOWLEDGE.md に今回ハマった Vercel SHA dedup の罠と、家族レビューからのフィードバック「Bot 応答までの無音が不安」を記録（Phase 2 二段返信の動機付け）

このセッションで実施した変更（Vercel env 分割・LINE DEV チャンネル新設・develop ブランチ作成）はすべて GitHub 外の操作で、リポ側の差分は本 PR の docs 更新のみ。

## Commit 構成

- `7802266` chore(deploy): trigger initial Vercel preview build for develop  
  develop が main と同じ SHA を指していたため Vercel が Preview デプロイを作らない問題（KNOWLEDGE.md 参照）。空 commit で分岐させた記録
- `d890092` docs(setup): document LINE channel duplication and develop branch workflow  
  実体の docs 更新（5 ファイル）

## Test plan

- [x] `npm run build` 通過（コード変更ゼロ）
- [x] LINE DEV チャンネル → sandbox リポに `[TEST]` Issue 起票成功（実機）
- [x] LINE 本番チャンネル → 同じく sandbox に `[TEST]` Issue 起票成功（regression: env 分離が効いている確認）
- [x] Vercel `mcp__vercel__vercel-get-environments` で `LINE_CHANNEL_SECRET` / `LINE_CHANNEL_ACCESS_TOKEN` が Production / (Preview+Development) の 2 エントリに分かれていることを確認
- [x] Preview URL `https://feedback-relay-bot-git-develop-hirobirofran-7375s-projects.vercel.app/api/line/webhook` が `{"ok":true}` を返すことを確認
- [ ] **マージ後**: main HEAD で本番チャンネルが引き続き動作することを LINE 実機で確認（regression）

## マージ後の運用変更

- 本 PR が初の develop → main PR
- 以降 Claude Code は原則 `develop` ブランチにコミットし、まとまったタイミングで PR を切る運用（WORKFLOW.md L51〜参照）
- main 直 push は緊急 hotfix 以外禁止

🤖 Generated with [Claude Code](https://claude.com/claude-code)